### PR TITLE
Remove 64BIT options from CFLAGS for g2clib build

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ fetch g2clib build and install. This should be converted to a port
 fetch http://www.nco.ncep.noaa.gov/pmb/codes/GRIB2/g2clib-1.6.0.tar
 tar xf g2clib-1.6.0.tar
 cd g2clib-1.6.0
+remove '-D__64BIT__' from the CFLAGS listed in 'makefile'
 gmake
 
 cp libg2c_v1.6.0.a /usr/local/lib/


### PR DESCRIPTION
Cory ran into an issue reading GRIB2 files with grads. He tracked down a similar issue and the fix was to remove the flag from the library build.
from some forum:
-------------------------------------
>>> I have tested reading netcdf and GRIB1 files and they work fine. However, I am not able to read GRIB2 files. I get the following error if I try to open a GRIB2 file that already had a .idx file produced:
>>>
>>> GRIB2 I/O Error: Predefined bitmap applies (ibmap=47244640267)
>>I belive this is related to a setting for CFLAGS in the grib2c library’s makefile. Try it without the “-D__64BIT__” .

>Great!  This worked well, I reran gribmap got all matches and it works in GrADS now.
---------------------------------------